### PR TITLE
Fix | Loading spinner for offline state

### DIFF
--- a/components/calendar/Calendar.tsx
+++ b/components/calendar/Calendar.tsx
@@ -47,15 +47,9 @@ const WeekdayBox = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.divider,
 }));
 
-const DayBox = styled(ButtonBase)(({ theme }) => ({
+const DayBox = styled(IconButton)(({ theme }) => ({
   width: "100%",
   aspectRatio: "1/1",
-
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-
-  borderRadius: "100%",
 }));
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -107,7 +101,7 @@ const Calendar: FC = () => {
             ml: 1,
           }}
         >
-          Calendar
+          History
         </Typography>
       </Box>
       <Card elevation={0} sx={{ p: 2, width: "100%" }}>
@@ -132,7 +126,7 @@ const Calendar: FC = () => {
           justifyContent="space-between"
           sx={{ width: "100%", flexDirection: { xs: "column", sm: "row" } }}
         >
-          <Box sx={{ mb: 3, mr: 2, minWidth: 280 }}>
+          <Box sx={{ mb: 3, mr: 2, minWidth: 230 }}>
             <Typography component="span" variant="body1" display="block">
               Last workout: Push Day, 12.06.2022.
             </Typography>

--- a/components/routine/CurrentRoutine.tsx
+++ b/components/routine/CurrentRoutine.tsx
@@ -8,7 +8,7 @@ import SelectRoutineModal from "../../components/modals/SelectRoutineModal";
 import RoutineHeader from "./RoutineHeader";
 import RoutineCarousel from "../../components/routine/RoutineCarousel";
 import RoutineFallbackCard from "./RoutineFallbackCard";
-import { CircularProgress, Box } from "@mui/material";
+import { CircularProgress, Box, Card } from "@mui/material";
 
 import { FallbackCardVariant } from "./RoutineFallbackCard";
 
@@ -58,14 +58,20 @@ const CurrentRoutine: FC = () => {
       />
 
       {showCircularProgress && (
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          sx={{ width: "100%", height: 260 }}
+        <Card
+          elevation={0}
+          sx={{
+            width: "100%",
+            height: "80vw",
+            maxHeight: 328,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            mb: 2,
+          }}
         >
           <CircularProgress />
-        </Box>
+        </Card>
       )}
 
       {!showCircularProgress && (

--- a/components/routine/RoutineFallbackCard.tsx
+++ b/components/routine/RoutineFallbackCard.tsx
@@ -45,9 +45,11 @@ const RoutineFallbackCard: FC<Props> = ({
 
   return (
     <Card
+      elevation={0}
       sx={{
         width: "100%",
-        height: 320,
+        height: "80vw",
+        maxHeight: 328,
         p: 2,
         mb: 2,
         display: "flex",

--- a/components/routine/RoutineHeader.tsx
+++ b/components/routine/RoutineHeader.tsx
@@ -26,7 +26,7 @@ const RoutineHeader: FC<Props> = ({ onSelectClick }) => {
       display="flex"
       justifyContent="space-between"
       alignItems="center"
-      sx={{ width: "100%" }}
+      sx={{ width: "100%", minHeight: 36 }}
     >
       <Typography
         component="span"

--- a/context/RoutinesContext.tsx
+++ b/context/RoutinesContext.tsx
@@ -30,14 +30,14 @@ export type Routine = {
 };
 
 type RoutinesContextValue = {
-  routines: Routine[] | undefined;
-  setRoutines: Dispatch<SetStateAction<Routine[] | undefined>>;
+  routines: Routine[];
+  setRoutines: Dispatch<SetStateAction<Routine[]>>;
   isLoading: boolean;
   currentRoutineId?: string;
 };
 
 const INITIAL_STATE = {
-  routines: undefined,
+  routines: [],
   setRoutines: () => {},
   isLoading: true,
   currentRoutineId: undefined,
@@ -47,9 +47,7 @@ export const RoutinesContext =
   createContext<RoutinesContextValue>(INITIAL_STATE);
 
 export const RoutinesProvider: FC = ({ children }: any) => {
-  const [routines, setRoutines] = useState<Routine[] | undefined>(
-    INITIAL_STATE.routines
-  );
+  const [routines, setRoutines] = useState<Routine[]>(INITIAL_STATE.routines);
   const [currentRoutineId, setCurrentRoutineId] = useState<string | undefined>(
     INITIAL_STATE.currentRoutineId
   );

--- a/context/RoutinesContext.tsx
+++ b/context/RoutinesContext.tsx
@@ -30,14 +30,14 @@ export type Routine = {
 };
 
 type RoutinesContextValue = {
-  routines: Routine[];
-  setRoutines: Dispatch<SetStateAction<Routine[]>>;
+  routines: Routine[] | undefined;
+  setRoutines: Dispatch<SetStateAction<Routine[] | undefined>>;
   isLoading: boolean;
   currentRoutineId?: string;
 };
 
 const INITIAL_STATE = {
-  routines: [],
+  routines: undefined,
   setRoutines: () => {},
   isLoading: true,
   currentRoutineId: undefined,
@@ -47,7 +47,9 @@ export const RoutinesContext =
   createContext<RoutinesContextValue>(INITIAL_STATE);
 
 export const RoutinesProvider: FC = ({ children }: any) => {
-  const [routines, setRoutines] = useState<Routine[]>(INITIAL_STATE.routines);
+  const [routines, setRoutines] = useState<Routine[] | undefined>(
+    INITIAL_STATE.routines
+  );
   const [currentRoutineId, setCurrentRoutineId] = useState<string | undefined>(
     INITIAL_STATE.currentRoutineId
   );
@@ -83,6 +85,8 @@ export const RoutinesProvider: FC = ({ children }: any) => {
     const unsubscribe = onSnapshot(
       routinesQuery,
       (querySnapshot) => {
+        if (querySnapshot.metadata.fromCache) return;
+
         const routines: Routine[] = [];
 
         querySnapshot.forEach((doc) => {

--- a/context/WorkoutsContext.tsx
+++ b/context/WorkoutsContext.tsx
@@ -51,8 +51,8 @@ type RoutineGroups = {
 };
 
 type WorkoutsContextValue = {
-  workouts: Workout[];
-  setWorkouts: Dispatch<SetStateAction<Workout[]>>;
+  workouts?: Workout[];
+  setWorkouts: Dispatch<SetStateAction<Workout[] | undefined>>;
   isLoading: boolean;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
   isSorted: boolean;
@@ -61,7 +61,7 @@ type WorkoutsContextValue = {
 };
 
 const INITIAL_STATE = {
-  workouts: [],
+  workouts: undefined,
   setWorkouts: () => {},
   isLoading: true,
   setIsLoading: () => {},
@@ -75,7 +75,9 @@ export const WorkoutsContext =
 
 export const WorkoutsProvider: FC = ({ children }: any) => {
   const [isSorted, setIsSorted] = useState(INITIAL_STATE.isSorted);
-  const [workouts, setWorkouts] = useState<Workout[]>([]);
+  const [workouts, setWorkouts] = useState<Workout[] | undefined>(
+    INITIAL_STATE.workouts
+  );
   const [routineGroups, setRoutineGroups] = useState<RoutineGroups>(
     INITIAL_STATE.routineGroups
   );
@@ -86,6 +88,7 @@ export const WorkoutsProvider: FC = ({ children }: any) => {
 
   useEffect(() => {
     console.log("updating  workouts data", workouts);
+    if (workouts) setIsLoading(false);
   }, [workouts]);
 
   // FETCH FROM FIRESTORE --------------------------
@@ -105,6 +108,8 @@ export const WorkoutsProvider: FC = ({ children }: any) => {
     const unsubscribe = onSnapshot(
       workoutsQuery,
       (querySnapshot) => {
+        if (querySnapshot.metadata.fromCache) return;
+
         const workouts: Workout[] = [];
 
         querySnapshot.forEach((doc) => {
@@ -133,7 +138,7 @@ export const WorkoutsProvider: FC = ({ children }: any) => {
 
   // SORT WORKOUTS DATA --------------------------
   useEffect(() => {
-    if (!routines) return;
+    if (!routines || !workouts) return;
     setRoutineGroups(sortWorkoutsByRoutine(routines, workouts));
   }, [routines, workouts]);
 

--- a/context/WorkoutsContext.tsx
+++ b/context/WorkoutsContext.tsx
@@ -51,8 +51,8 @@ type RoutineGroups = {
 };
 
 type WorkoutsContextValue = {
-  workouts?: Workout[];
-  setWorkouts: Dispatch<SetStateAction<Workout[] | undefined>>;
+  workouts: Workout[];
+  setWorkouts: Dispatch<SetStateAction<Workout[]>>;
   isLoading: boolean;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
   isSorted: boolean;
@@ -61,7 +61,7 @@ type WorkoutsContextValue = {
 };
 
 const INITIAL_STATE = {
-  workouts: undefined,
+  workouts: [],
   setWorkouts: () => {},
   isLoading: true,
   setIsLoading: () => {},
@@ -75,9 +75,7 @@ export const WorkoutsContext =
 
 export const WorkoutsProvider: FC = ({ children }: any) => {
   const [isSorted, setIsSorted] = useState(INITIAL_STATE.isSorted);
-  const [workouts, setWorkouts] = useState<Workout[] | undefined>(
-    INITIAL_STATE.workouts
-  );
+  const [workouts, setWorkouts] = useState<Workout[]>(INITIAL_STATE.workouts);
   const [routineGroups, setRoutineGroups] = useState<RoutineGroups>(
     INITIAL_STATE.routineGroups
   );
@@ -88,7 +86,6 @@ export const WorkoutsProvider: FC = ({ children }: any) => {
 
   useEffect(() => {
     console.log("updating  workouts data", workouts);
-    if (workouts) setIsLoading(false);
   }, [workouts]);
 
   // FETCH FROM FIRESTORE --------------------------


### PR DESCRIPTION
Adds condition on subscriptions to Firestore to not show fallback card if offline.